### PR TITLE
orm: made OneToMany and ManyToOne nullable also for GQL

### DIFF
--- a/examples/orm-example/models/Task.ts
+++ b/examples/orm-example/models/Task.ts
@@ -31,9 +31,9 @@ export default class Task extends BaseEntity {
   @QueryPermissions(["Anyone", { name: "Owner", params: { field: "userId" } }])
   public title: string;
 
-  @ManyToOne((type) => User)
+  @ManyToOne((type) => User, "tasks", ({ nullable: true }))
   @QueryPermissions(["Anyone"])
-  public user: User;
+  public user?: User;
 
   @Column({ gqlType: "String", type: "character varying" })
   @QueryPermissions(["Anyone", { name: "Owner", params: { field: "userId" } }])

--- a/packages/db/lib/decorator/ManyToOne.ts
+++ b/packages/db/lib/decorator/ManyToOne.ts
@@ -15,7 +15,7 @@ export default function ManyToOne<T>(typeFunction: (type?: any) => new () => T, 
       const foreignEntityName = identifier ? identifier.name : `Unknown${Math.floor(Math.random() * 100)}`;
       const relationName = entityName < foreignEntityName ? `${entityName}_${foreignEntityName}` : `${foreignEntityName}_${entityName}`;
       const directive = `@relation(name: "${columnName}_${relationName}")`;
-      ModelMeta.createColumnMeta(entityName, columnName, { gqlType: foreignEntityName }, [directive]);
+      ModelMeta.createColumnMeta(entityName, columnName, { gqlType: foreignEntityName, nullable: options ? options.nullable : false }, [directive]);
 
       if (inverseSide == null) typeorm.ManyToOne(typeFunction, (object: T) => object[inverseSide], options)(target, columnName);
       else typeorm.ManyToOne(typeFunction, options)(target, columnName);

--- a/packages/db/lib/decorator/OneToMany.ts
+++ b/packages/db/lib/decorator/OneToMany.ts
@@ -15,7 +15,7 @@ export default function OneToMany<T>(typeFunction: (type?: any) => new () => T, 
       const foreignEntityName = identifier ? identifier.name : `Unknown${Math.floor(Math.random() * 100)}`;
       const relationName = entityName < foreignEntityName ? `${entityName}_${foreignEntityName}` : `${foreignEntityName}_${entityName}`;
       const directive = `@relation(name: "${inverseSide}_${relationName}")`;
-      ModelMeta.createColumnMeta(entityName, columnName, { gqlType: `[${foreignEntityName}!]` }, [directive]);
+      ModelMeta.createColumnMeta(entityName, columnName, { gqlType: `[${foreignEntityName}!]`, nullable: options ? options.nullable : false }, [directive]);
 
       typeorm.OneToMany(typeFunction, (object: T) => object[inverseSide], options)(target, columnName);
       ModelMeta.setColumnSynchronizedTrue(entityName, columnName);

--- a/packages/db/lib/decorator/OneToMany.ts
+++ b/packages/db/lib/decorator/OneToMany.ts
@@ -15,7 +15,9 @@ export default function OneToMany<T>(typeFunction: (type?: any) => new () => T, 
       const foreignEntityName = identifier ? identifier.name : `Unknown${Math.floor(Math.random() * 100)}`;
       const relationName = entityName < foreignEntityName ? `${entityName}_${foreignEntityName}` : `${foreignEntityName}_${entityName}`;
       const directive = `@relation(name: "${inverseSide}_${relationName}")`;
-      ModelMeta.createColumnMeta(entityName, columnName, { gqlType: `[${foreignEntityName}!]`, nullable: options ? options.nullable : false }, [directive]);
+      ModelMeta.createColumnMeta(entityName, columnName, { gqlType: `[${foreignEntityName}!]`, nullable: options ? options.nullable : false }, [
+        directive
+      ]);
 
       typeorm.OneToMany(typeFunction, (object: T) => object[inverseSide], options)(target, columnName);
       ModelMeta.setColumnSynchronizedTrue(entityName, columnName);


### PR DESCRIPTION
Also apply the nullable option in `@OneToMany` and in `@ManyToOne` to the column meta and thus to the graphql schema.

Fixed example and tested manually. See below.