### PR TITLE
db: make strip_all_triggers case-sensitive

### DIFF
--- a/packages/db/res/1560161087095-meta-functions/strip_all_triggers.up.sql
+++ b/packages/db/res/1560161087095-meta-functions/strip_all_triggers.up.sql
@@ -5,7 +5,7 @@ BEGIN
     FOR triggNameRecord IN select distinct(trigger_name) from information_schema.triggers where trigger_schema = 'public' LOOP
         FOR triggTableRecord IN SELECT distinct(event_object_table) from information_schema.triggers where trigger_name = triggNameRecord.trigger_name LOOP
             RAISE NOTICE 'Dropping trigger: % on table: %', triggNameRecord.trigger_name, triggTableRecord.event_object_table;
-            EXECUTE 'DROP TRIGGER ""' || triggNameRecord.trigger_name || '"" ON "' || triggTableRecord.event_object_table || '";';
+            EXECUTE 'DROP TRIGGER "' || triggNameRecord.trigger_name || '" ON "' || triggTableRecord.event_object_table || '";';
         END LOOP;
     END LOOP;
 

--- a/packages/db/res/1560161087095-meta-functions/strip_all_triggers.up.sql
+++ b/packages/db/res/1560161087095-meta-functions/strip_all_triggers.up.sql
@@ -5,7 +5,7 @@ BEGIN
     FOR triggNameRecord IN select distinct(trigger_name) from information_schema.triggers where trigger_schema = 'public' LOOP
         FOR triggTableRecord IN SELECT distinct(event_object_table) from information_schema.triggers where trigger_name = triggNameRecord.trigger_name LOOP
             RAISE NOTICE 'Dropping trigger: % on table: %', triggNameRecord.trigger_name, triggTableRecord.event_object_table;
-            EXECUTE 'DROP TRIGGER ' || triggNameRecord.trigger_name || ' ON "' || triggTableRecord.event_object_table || '";';
+            EXECUTE 'DROP TRIGGER ""' || triggNameRecord.trigger_name || '"" ON "' || triggTableRecord.event_object_table || '";';
         END LOOP;
     END LOOP;
 


### PR DESCRIPTION
The function was failing for triggers with names as `table_file_trigger_public_Document`